### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ docker run -d --gpus all -p 9000:9000 whisper-asr-webservice-gpu
 docker run -d --gpus all -p 9000:9000 -e ASR_MODEL=base whisper-asr-webservice-gpu
 ```
 
+## Cache
+The ASR model is downloaded each time you start the container, using the large model this can take some time. If you want to decrease the time it takes to start your container by skipping the download, you can store the cache directory (/root/.cache/whisper) to an persistent storage. Next time you start your container the ASR Model will be taken from the cache instead of being downloaded again.
+
+**Important this will prevent you from receiving any updates to the models.**
+ 
+```sh
+docker run -d -p 9000:9000 -e ASR_MODEL=large -v //c/tmp/whisper:/root/.cache/whisper onerahmet/openai-whisper-asr-webservice:latest
+```
+
+
 ## TODO
 
 - Unit tests


### PR DESCRIPTION
Hello

Testing out the container, I noticed it took some time to start using the large model. The reason was that the container downloaded the model (2.6 GB) from internet each time I started the container 

There is an easy configuration change for us who needs it, I thought it could be valuable to document for other users.


