### PR TITLE
Add an optional param to skip the encoding step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 RUN python3 -m venv $POETRY_VENV \
     && $POETRY_VENV/bin/pip install -U pip setuptools \
-    && $POETRY_VENV/bin/pip install poetry
+    && $POETRY_VENV/bin/pip install poetry==1.4.0
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -18,7 +18,7 @@ RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
 
 RUN python3 -m venv $POETRY_VENV \
     && $POETRY_VENV/bin/pip install -U pip setuptools \
-    && $POETRY_VENV/bin/pip install poetry
+    && $POETRY_VENV/bin/pip install poetry==1.4.0
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
 

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -66,9 +66,10 @@ def transcribe(
                 language: Union[str, None] = Query(default=None, enum=LANGUAGE_CODES),
                 initial_prompt: Union[str, None] = Query(default=None),
                 output : Union[str, None] = Query(default="txt", enum=[ "txt", "vtt", "srt", "tsv", "json"]),
+                encode : bool = Query(default=True, description="Encode audio first through ffmpeg")
                 ):
 
-    result = run_asr(audio_file.file, task, language, initial_prompt)
+    result = run_asr(audio_file.file, task, language, initial_prompt, encode)
     filename = audio_file.filename.split('.')[0]
     myFile = StringIO()
     if(output == "srt"):
@@ -91,10 +92,11 @@ def transcribe(
 @app.post("/detect-language", tags=["Endpoints"])
 def language_detection(
                 audio_file: UploadFile = File(...),
+                encode : bool = Query(default=True, description="Encode audio first through ffmpeg")
                 ):
 
     # load audio and pad/trim it to fit 30 seconds
-    audio = load_audio(audio_file.file)
+    audio = load_audio(audio_file.file, encode)
     audio = whisper.pad_or_trim(audio)
 
     # make log-Mel spectrogram and move to the same device as the model
@@ -111,8 +113,8 @@ def language_detection(
     return result
 
 
-def run_asr(file: BinaryIO, task: Union[str, None], language: Union[str, None], initial_prompt: Union[str, None] ):
-    audio = load_audio(file)
+def run_asr(file: BinaryIO, task: Union[str, None], language: Union[str, None], initial_prompt: Union[str, None], encode=True):
+    audio = load_audio(file, encode)
     options_dict = {"task" : task}
     if language:
         options_dict["language"] = language    
@@ -124,7 +126,7 @@ def run_asr(file: BinaryIO, task: Union[str, None], language: Union[str, None], 
     return result
 
 
-def load_audio(file: BinaryIO, sr: int = SAMPLE_RATE):
+def load_audio(file: BinaryIO, encode=True, sr: int = SAMPLE_RATE):
     """
     Open an audio file object and read as mono waveform, resampling as necessary.
     Modified from https://github.com/openai/whisper/blob/main/whisper/audio.py to accept a file object
@@ -132,21 +134,26 @@ def load_audio(file: BinaryIO, sr: int = SAMPLE_RATE):
     ----------
     file: BinaryIO
         The audio file like object
+    encode: Boolean
+        If true, encode audio stream to WAV before sending to whisper
     sr: int
         The sample rate to resample the audio if necessary
     Returns
     -------
     A NumPy array containing the audio waveform, in float32 dtype.
     """
-    try:
-        # This launches a subprocess to decode audio while down-mixing and resampling as necessary.
-        # Requires the ffmpeg CLI and `ffmpeg-python` package to be installed.
-        out, _ = (
-            ffmpeg.input("pipe:", threads=0)
-            .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=sr)
-            .run(cmd="ffmpeg", capture_stdout=True, capture_stderr=True, input=file.read())
-        )
-    except ffmpeg.Error as e:
-        raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+    if encode:
+        try:
+            # This launches a subprocess to decode audio while down-mixing and resampling as necessary.
+            # Requires the ffmpeg CLI and `ffmpeg-python` package to be installed.
+            out, _ = (
+                ffmpeg.input("pipe:", threads=0)
+                .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=sr)
+                .run(cmd="ffmpeg", capture_stdout=True, capture_stderr=True, input=file.read())
+            )
+        except ffmpeg.Error as e:
+            raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+    else:
+        out = file.read()
 
     return np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0


### PR DESCRIPTION
Adds a new `encode` parameter to asr and detect-language endpoints, which when set to `false`, skips the ffmpeg encoding process and sends the file directly to whisper. I implemented this to avoid the #42 M4A/MP4 issue which occurs when trying to stream the input file. The simplest way to solve this was to encode on the client-side and send that directly to the ASR.