### PR TITLE
"Word level timestamps" was misspelled.

### DIFF
--- a/app/webservice.py
+++ b/app/webservice.py
@@ -66,7 +66,7 @@ async def asr(
         audio_file: UploadFile = File(...),
         encode: bool = Query(default=True, description="Encode audio first through ffmpeg"),
         output: Union[str, None] = Query(default="txt", enum=["txt", "vtt", "srt", "tsv", "json"]),
-        word_timestamps: bool = Query(default=False, description="World level timestamps")
+        word_timestamps: bool = Query(default=False, description="Word level timestamps")
 ):
     result = transcribe(load_audio(audio_file.file, encode), task, language, initial_prompt, word_timestamps, output)
     return StreamingResponse(


### PR DESCRIPTION
I'm pretty sure this feature is for word-level timestamps, rather than world-level ones.