### PR TITLE
Remove GPL2.0 dependency

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -27,6 +27,12 @@ Starting the Webservice:
 poetry run gunicorn --bind 0.0.0.0:9000 --workers 1 --timeout 0 app.webservice:app -k uvicorn.workers.UvicornWorker
 ```
 
+Starting the Webservice on Windows:
+
+```sh
+poetry run gunicorn --bind 0.0.0.0:9000 --workers 1 --timeout 0 app.webservice:app -k uvicorn.workers.UvicornWorker
+```
+
 ### Build
 
 === ":octicons-file-code-16: `Poetry`"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1397,17 +1397,6 @@ files = [
 ]
 
 [[package]]
-name = "unidecode"
-version = "1.3.6"
-description = "ASCII transliterations of Unicode text"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "Unidecode-1.3.6-py3-none-any.whl", hash = "sha256:547d7c479e4f377b430dd91ac1275d593308dce0fc464fb2ab7d41f82ec653be"},
-    {file = "Unidecode-1.3.6.tar.gz", hash = "sha256:fed09cf0be8cf415b391642c2a5addfc72194407caee4f98719e40ec2a72b830"},
-]
-
-[[package]]
 name = "urllib3"
 version = "1.26.15"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1608,4 +1597,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b8fdf91ceb9a85c7f4156a0f4fbac1c2d19d449884896ebe60d9dbe18270c89d"
+content-hash = "94e50c45c5d3e7dd496ffd02af466bf6bb080283330f4e8cbd066faf13f49ca4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ priority = "explicit"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-unidecode = "^1.3.4"
 uvicorn = { extras = ["standard"], version = "^0.18.2" }
 gunicorn = "^20.1.0"
 tqdm = "^4.64.1"
@@ -35,7 +34,7 @@ torch = [
   {markers = "sys_platform == 'darwin' and platform_machine == 'x86_64'", url = "https://download.pytorch.org/whl/cpu/torch-1.13.0-cp310-none-macosx_10_9_x86_64.whl"},
   {markers = "sys_platform == 'linux' and platform_machine == 'aarch64'", url="https://download.pytorch.org/whl/torch-1.13.0-cp310-cp310-manylinux2014_aarch64.whl"},
   {markers = "sys_platform == 'linux' and platform_machine == 'x86_64'", url="https://download.pytorch.org/whl/cpu/torch-1.13.0%2Bcpu-cp310-cp310-linux_x86_64.whl"},
-  {markers = "sys_platform == 'win' and platform_machine == 'amd64'", url="https://download.pytorch.org/whl/cpu/torch-1.13.0%2Bcpu-cp310-cp310-win_amd64.whl"},
+  {markers = "sys_platform == 'win32' and platform_machine == 'AMD64'", url = "https://download.pytorch.org/whl/cpu/torch-1.13.0%2Bcpu-cp310-cp310-win_amd64.whl"},
 ]
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
**IMPOTANT** I am very new to the Python so please be very careful with this PR.. 

If I understood correctly dependency on unicode is redundant and not used at all so I removed it from pyproject.toml

After that executed **poetry lock --no-update**

And MANUALY removed the `triton` dependency from `poetry.lock`