### PR TITLE
Add image EXPOSE commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js swagger-ui-ass
 RUN poetry config virtualenvs.in-project true
 RUN poetry install
 
+EXPOSE 9000
+
 ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:9000", "--workers", "1", "--timeout", "0", "app.webservice:app", "-k", "uvicorn.workers.UvicornWorker"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -37,4 +37,6 @@ COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js swagger-ui-ass
 RUN poetry install
 RUN $POETRY_VENV/bin/pip install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch
 
+EXPOSE 9000
+
 CMD gunicorn --bind 0.0.0.0:9000 --workers 1 --timeout 0 app.webservice:app -k uvicorn.workers.UvicornWorker


### PR DESCRIPTION
Took a while troubleshooting why my connected images weren't able to reach the API as expected despite being able to ping the container by name. 

Added EXPOSE commands to the Dockerfiles to remove the need to add expose to docker run / docker-compose configs. 