### PR TITLE
Add ALLOW_ORIGINS Environment Variable

### DIFF
--- a/app/webservice.py
+++ b/app/webservice.py
@@ -9,6 +9,8 @@ from fastapi import FastAPI, File, UploadFile, Query, applications
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import StreamingResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+
 from whisper import tokenizer
 from urllib.parse import quote
 
@@ -20,6 +22,7 @@ else:
 
 SAMPLE_RATE = 16000
 LANGUAGE_CODES = sorted(list(tokenizer.LANGUAGES.keys()))
+ORIGINS = os.getenv("ORIGINS", "*").split(",")
 
 projectMetadata = importlib.metadata.metadata('whisper-asr-webservice')
 app = FastAPI(
@@ -34,6 +37,14 @@ app = FastAPI(
         "name": "MIT License",
         "url": projectMetadata['License']
     }
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ORIGINS,
+    allow_credentials=True,
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
 )
 
 assets_path = os.getcwd() + "/swagger-ui-assets"

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -22,7 +22,7 @@ else:
 
 SAMPLE_RATE = 16000
 LANGUAGE_CODES = sorted(list(tokenizer.LANGUAGES.keys()))
-ORIGINS = os.getenv("ORIGINS", "*").split(",")
+ORIGINS = os.getenv("ALLOW_ORIGINS", "*").split(",")
 
 projectMetadata = importlib.metadata.metadata('whisper-asr-webservice')
 app = FastAPI(
@@ -63,7 +63,6 @@ if path.exists(assets_path + "/swagger-ui.css") and path.exists(assets_path + "/
 
 
     applications.get_swagger_ui_html = swagger_monkey_patch
-
 
 @app.get("/", response_class=RedirectResponse, include_in_schema=False)
 async def index():

--- a/docs/environmental-variables.md
+++ b/docs/environmental-variables.md
@@ -25,3 +25,31 @@ For English-only applications, the `.en` models tend to perform better, especial
 ```sh
 export ASR_MODEL_PATH=/data/whisper
 ```
+
+### Configuring the `ALLOW_ORIGINS`
+
+```sh
+export ALLOW_ORIGINS
+```
+**Default: `*`**
+
+List the origins that are allowed to access the model. Wild cards are supported.
+
+**Docker-compose example**
+```
+services:
+  openai-whisper-asr:
+    image: onerahmet/openai-whisper-asr-webservice:latest
+    environment:
+      - ASR_MODEL=base
+      - ASR_ENGINE=openai_whisper
+      - ALLOW_ORIGINS=https://example.com
+```
+**Adding multiple**
+```
+- ALLOW_ORIGINS=https://example.com, https://second_example.com, https://third_example.com
+```
+**Wildcards**
+```
+- ALLOW_ORIGINS=https://*.exmaple.com
+```


### PR DESCRIPTION
# Add **ALLOW_ORIGINS** environment variable
Adds the **ALLOW_ORIGINS** environment variable to be set on the docker container. This is important for interfacing with the container from a website using fetch, as the browser will block the contents of the response if the appropriate headers are not present. This change ensures the headers are present on allowed origins.
It imports the middleware package from **FastAPI** to handle the origin matching.

Example with docker-compose
```yml
version: '3.7'

services:
  openai-whisper-asr:
    container_name: whisper
    image: onerahmet/openai-whisper-asr-webservice:latest-gpu
    ports:
      - "9000:9000"
    environment:
      - ASR_MODEL=base
      - ASR_ENGINE=openai_whisper
      - ALLOW_ORIGINS=https://example.com
    deploy:
      resources:
        reservations:
          devices:
            - driver: nvidia
              count: 1
              capabilities: [gpu]
```

The default behavior is to allow any origins **`*`** (Wild cards are supported `https://*.example.com`)
The variable is comma separated, so adding multiple origins can be done like so:
```
- ALLOW_ORIGINS=https://example.com, https://second_example.com, https://third_example.com
```

Docs have also been updated with this information