### PR TITLE
Fix typo in Endpoints Documentation

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -22,7 +22,7 @@ There are 2 endpoints available:
 | Name            | Values                                         |
 |-----------------|------------------------------------------------|
 | audio_file      | File                                           |
-| output          | `text` (default), `json`, `vtt`, `strt`, `tsv` |
+| output          | `text` (default), `json`, `vtt`, `srt`, `tsv` |
 | task            | `transcribe`, `translate`                      |
 | language        | `en` (default is auto recognition)             |
 | word_timestamps | false (default)                                |


### PR DESCRIPTION
Fix typo mentioning `strt`  instead of `srt` in endpoint documentation