### PR TITLE
Fix language detection runtime error

### DIFF
--- a/app/openai_whisper/core.py
+++ b/app/openai_whisper/core.py
@@ -48,7 +48,7 @@ def language_detection(audio):
     audio = whisper.pad_or_trim(audio)
 
     # make log-Mel spectrogram and move to the same device as the model
-    mel = whisper.log_mel_spectrogram(audio, n_mels=128).to(model.device)
+    mel = whisper.log_mel_spectrogram(audio, model.dims.n_mels).to(model.device)
 
     # detect the spoken language
     with model_lock:

--- a/app/openai_whisper/core.py
+++ b/app/openai_whisper/core.py
@@ -48,7 +48,7 @@ def language_detection(audio):
     audio = whisper.pad_or_trim(audio)
 
     # make log-Mel spectrogram and move to the same device as the model
-    mel = whisper.log_mel_spectrogram(audio).to(model.device)
+    mel = whisper.log_mel_spectrogram(audio, n_mels=128).to(model.device)
 
     # detect the spoken language
     with model_lock:


### PR DESCRIPTION
I get a runtime exception when trying to detect language of a mp3 file:

```
RuntimeError: Given groups=1, weight of size [1280, 128, 3], expected input[1, 80, 3000] to have 128 channels, but got 80 channels instead
```
This change fixes that.

See: https://github.com/openai/whisper/pull/1764#issuecomment-1817497095