### PR TITLE
Enable VAD Filtering by default when using faster whisper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+### Fixed
+
+- Fix VAD Filtering enable logic to match documentation
+
 [1.7.1] (2024-12-18)
 --------------------
 

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -67,7 +67,7 @@ async def asr(
                 description="Enable the voice activity detection (VAD) to filter out parts of the audio without speech",
                 include_in_schema=(True if CONFIG.ASR_ENGINE == "faster_whisper" else False),
             ),
-        ] = False,
+        ] = (CONFIG.ASR_ENGINE == "faster_whisper"),
         word_timestamps: bool = Query(default=False, description="Word level timestamps"),
         output: Union[str, None] = Query(default="txt", enum=["txt", "vtt", "srt", "tsv", "json"]),
 ):


### PR DESCRIPTION
VAD Filtering is described in the code as being enabled by default when using faster_whisper engine. This is not actually the case as it would always default to false. I have added logic to have VAD filtering act as described within the webservice. This closes #274 