### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM swaggerapi/swagger-ui:v5.9.1 AS swagger-ui
 
 FROM python:3.10-bookworm
 
+LABEL org.opencontainers.image.source="https://github.com/ahmetoner/whisper-asr-webservice"
+
 ENV POETRY_VENV=/app/.venv
 
 RUN python3 -m venv $POETRY_VENV \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -4,6 +4,8 @@ FROM swaggerapi/swagger-ui:v5.9.1 AS swagger-ui
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 
+LABEL org.opencontainers.image.source="https://github.com/ahmetoner/whisper-asr-webservice"
+
 ENV PYTHON_VERSION=3.10
 
 ENV POETRY_VENV=/app/.venv


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md