### PR TITLE
📦[Feature] Support for async job offloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
 WORKDIR := /tmp/whisper_asr_webservice
+DOCKER_IMAGE_LATEST := whisper-asr-webservice:latest
 
 dev-up:
 	 poetry run whisper-asr-webservice --host 0.0.0.0 --port 9000
 clean:
 	rm -rf $(WORKDIR)
+
+build-cpu-image:
+	docker buildx build . -t $(DOCKER_IMAGE_LATEST) -f Dockerfile
+
+build-cpu-image-arm:
+	docker buildx build . --platform linux/arm64 -t $(DOCKER_IMAGE_LATEST) -f Dockerfile
+
+build-gpu-image:
+	docker buildx build . -t $(DOCKER_IMAGE_LATEST)-gpu -f Dockerfile.gpu

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+WORKDIR := /tmp/whisper_asr_webservice
+
+dev-up:
+	 poetry run whisper-asr-webservice --host 0.0.0.0 --port 9000
+clean:
+	rm -rf $(WORKDIR)

--- a/app/async_svc.py
+++ b/app/async_svc.py
@@ -9,23 +9,13 @@ from typing import Dict, List, Literal
 from uuid import uuid4
 
 from fastapi import UploadFile
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from app.config import CONFIG
 from app.factory.asr_model_factory import ASRModel
 from app.utils import load_audio
 
 JobStatus = Literal["pending", "processing", "completed", "read", "failed", "error"]
-
-
-class Job(BaseModel):
-    id: str = Field(default_factory=lambda: str(uuid4()))
-    status: JobStatus
-    created_at: float | None = None
-    completed_at: float | None = None
-    file_location: str
-    results_file: str | None = None
-    error: str | None = None
 
 
 class NewAsyncJobResponse(BaseModel):

--- a/app/async_svc.py
+++ b/app/async_svc.py
@@ -1,0 +1,289 @@
+import json
+import os
+import shutil
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Literal
+from uuid import uuid4
+
+from fastapi import UploadFile
+from pydantic import BaseModel, Field
+
+from app.config import CONFIG
+from app.factory.asr_model_factory import ASRModel
+from app.utils import load_audio
+
+JobStatus = Literal["pending", "processing", "completed", "read", "failed", "error"]
+
+
+class Job(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    status: JobStatus
+    created_at: float | None = None
+    completed_at: float | None = None
+    file_location: str
+    results_file: str | None = None
+    error: str | None = None
+
+
+class NewAsyncJobResponse(BaseModel):
+    job_id: str
+    status: JobStatus
+    place_in_queue: int | None = None
+
+
+class AsyncJobResponse(BaseModel):
+    job_id: str
+    status: JobStatus
+    created_at: float | None = None
+    completed_at: float | None = None
+    results: List[Dict] | None = None
+    error: str | None = None
+
+
+class AsyncProcessing:
+    def __init__(self, asr_model: ASRModel):
+        self.workdir = Path(CONFIG.WORKDIR)
+        self.db_path = self.workdir / "data.db"
+        self.temp_store = self.workdir / "files"
+
+        self.workdir.mkdir(parents=True, exist_ok=True)
+        self.temp_store.mkdir(parents=True, exist_ok=True)
+        self.init_db()
+        self.db_lock = threading.Lock()
+        self.process_lock = threading.Lock()
+
+        self.asr_model = asr_model
+
+        # Start background processing thread
+        self.processing_thread = threading.Thread(name="async_processing", target=self._process_jobs, daemon=True)
+        self.cleanup_thread = threading.Thread(name="cleanup_old_jobs", target=self.cleanup_old_jobs, daemon=True)
+
+        # Start background threads
+        self.processing_thread.start()
+        self.cleanup_thread.start()
+
+    def init_db(self):
+        """Setup the database"""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS jobs (
+                    id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    completed_at REAL,
+                    file_location TEXT,
+                    results_file TEXT,
+                    error TEXT,
+                    params TEXT
+                )
+            """)
+            conn.commit()
+
+    def cleanup_old_jobs(self):
+        """Remove old jobs from the database and filesystem"""
+        abandoned_time_max = CONFIG.JOB_CLEANUP_ABANDONED
+        read_time_max = CONFIG.JOB_CLEANUP_AFTER_READ
+
+        while True:
+            cutoff_time = time.time() - read_time_max
+            abandoned_cutoff_time = time.time() - abandoned_time_max
+            try:
+                with self.db_lock:
+                    with sqlite3.connect(self.db_path) as conn:
+                        # Get old job files to delete
+                        cursor_1 = conn.execute(
+                            "SELECT id, file_location, results_file FROM jobs WHERE created_at < ? AND (status = 'read' OR status = 'failed')",
+                            (cutoff_time,),
+                        )
+                        cursor_2 = conn.execute(
+                            "SELECT id, file_location, results_file FROM jobs WHERE created_at < ? AND (status = 'pending' OR status = 'processing')",
+                            (abandoned_cutoff_time,),
+                        )
+                        old_jobs = cursor_1.fetchall() + cursor_2.fetchall()
+
+                        # Delete files
+                        for _, file_location, results_file in old_jobs:
+                            if file_location:
+                                file_path = Path(file_location)
+                                if file_path.exists() and file_path.is_dir():
+                                    shutil.rmtree(file_path)
+                            if results_file:
+                                results_path = Path(results_file)
+                                if results_path.exists():
+                                    results_path.unlink(missing_ok=True)
+
+                        # Delete database records
+                        job_ids = [job[0] for job in old_jobs]
+                        if job_ids:
+                            placeholders = ",".join(["?" for _ in job_ids])
+                            conn.execute(f"DELETE FROM jobs WHERE id IN ({placeholders})", job_ids)
+                            conn.commit()
+
+                time.sleep(60)
+            except Exception as e:
+                print(f"Error in cleanup_old_jobs: {e}")
+                time.sleep(5)
+
+    async def create_job(self, files: List[UploadFile], params: Dict) -> NewAsyncJobResponse:
+        """Create a new job and store files to temp_store"""
+        job_id = str(uuid4())
+        job_dir = self.temp_store / job_id
+        job_dir.mkdir(exist_ok=True)
+
+        # Store uploaded files
+        stored_files = []
+        for _, file in enumerate(files):
+            file_path = job_dir / f"{file.filename}"
+            with open(file_path, "wb") as f:
+                content = file.file.read()
+                f.write(content)
+            stored_files.append(str(file_path))
+
+        # Create job record in database and get queue position
+        with self.db_lock:
+            with sqlite3.connect(self.db_path) as conn:
+                created_at = time.time()
+                conn.execute(
+                    "INSERT INTO jobs (id, status, created_at, file_location, params) VALUES (?, ?, ?, ?, ?)",
+                    (job_id, "pending", created_at, str(job_dir), json.dumps(params)),
+                )
+
+                # Get the position of this job in the queue
+                cursor = conn.execute(
+                    "SELECT COUNT(*) FROM jobs WHERE status = 'pending' AND (created_at < ? OR (created_at = ? AND id <= ?))",
+                    (created_at, created_at, job_id),
+                )
+                place_in_queue = cursor.fetchone()[0]
+
+                conn.commit()
+
+        return NewAsyncJobResponse(job_id=job_id, status="pending", place_in_queue=place_in_queue)
+
+    async def get_job(self, job_id: str) -> AsyncJobResponse:
+        """Get job status and results"""
+        with self.db_lock:
+            with sqlite3.connect(self.db_path) as conn:
+                cursor = conn.execute(
+                    "SELECT id, status, created_at, completed_at, file_location, results_file, error FROM jobs WHERE id = ?",
+                    (job_id,),
+                )
+                row = cursor.fetchone()
+
+        if not row:
+            return AsyncJobResponse(job_id=job_id, status="error", error="Job not found. It may have expired.")
+
+        job_id, status, created_at, completed_at, file_location, results_file, error = row
+
+        job_data = AsyncJobResponse(
+            job_id=job_id,
+            status=status,
+            created_at=created_at,
+            completed_at=completed_at,
+            results=None,
+            error=error,
+        )
+        complete_states = ["completed", "read"]
+        if status in complete_states and results_file:
+            try:
+                with open(results_file, "r") as f:
+                    job_data.results = json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                job_data.error = "Results file not found or corrupted"
+        elif status == "failed" and error:
+            job_data.error = error
+
+        if status == "completed":
+            # Mark job as read
+            with self.db_lock:
+                with sqlite3.connect(self.db_path) as conn:
+                    conn.execute("UPDATE jobs SET status = 'read' WHERE id = ?", (job_id,))
+                    conn.commit()
+
+        return job_data
+
+    def _process_jobs(self):
+        """Background thread to process pending jobs"""
+        while True:
+            try:
+                # Get next pending job
+                with self.db_lock:
+                    with sqlite3.connect(self.db_path) as conn:
+                        cursor = conn.execute(
+                            'SELECT id, file_location, params FROM jobs WHERE status = "pending" ORDER BY created_at LIMIT 1'
+                        )
+                        row = cursor.fetchone()
+
+                        if row:
+                            job_id, file_location, params_json = row
+                            # Mark as processing
+                            conn.execute('UPDATE jobs SET status = "processing" WHERE id = ?', (job_id,))
+                            conn.commit()
+
+                if row:
+                    self._process_single_job(job_id, file_location, json.loads(params_json))
+                else:
+                    # No pending jobs, sleep
+                    time.sleep(1)
+
+            except Exception as e:
+                print(f"Error in job processing thread: {e}")
+                time.sleep(5)
+
+    def _process_single_job(self, job_id: str, file_path: str, params: Dict):
+        """Process a single job"""
+        with self.process_lock:
+            try:
+                results = []
+                path = Path(file_path)
+                for file_name in os.listdir(file_path):
+                    with open(path / file_name, "rb") as f:
+                        result_stream = self.asr_model.transcribe(
+                            audio=load_audio(f, params.get("encode", True)),
+                            task=params.get("task", "transcribe"),
+                            language=params.get("language"),
+                            initial_prompt=params.get("initial_prompt"),
+                            vad_filter=params.get("vad_filter", False),
+                            word_timestamps=params.get("word_timestamps", False),
+                            options={
+                                "diarize": params.get("diarize", False),
+                                "min_speakers": params.get("min_speakers"),
+                                "max_speakers": params.get("max_speakers"),
+                            },
+                            output=params.get("output", "txt"),
+                        )
+
+                        # Read the entire stream result
+                        if result_stream:
+                            content = result_stream.read()
+                        else:
+                            content = ""
+
+                        results.append({"filename": file_name, "content": content})
+
+                # Save results to file
+                results_file = self.temp_store / job_id / "results.json"
+                with open(results_file, "w") as f:
+                    json.dump(results, f)
+
+                # Update job status
+                with self.db_lock:
+                    with sqlite3.connect(self.db_path) as conn:
+                        conn.execute(
+                            'UPDATE jobs SET status = "completed", completed_at = ?, results_file = ? WHERE id = ?',
+                            (time.time(), str(results_file), job_id),
+                        )
+                        conn.commit()
+
+            except Exception as e:
+                # Mark job as failed
+                with self.db_lock:
+                    with sqlite3.connect(self.db_path) as conn:
+                        print(f"Marking job {job_id} as failed: {e}")
+                        conn.execute(
+                            'UPDATE jobs SET status = "failed", completed_at = ?, error = ? WHERE id = ?',
+                            (time.time(), str(e), job_id),
+                        )
+                        conn.commit()

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class CONFIG:
     Configuration class for ASR models.
     Reads environment variables for runtime configuration, with sensible defaults.
     """
+
     # Determine the ASR engine ('faster_whisper', 'openai_whisper' or 'whisperx')
     ASR_ENGINE = os.getenv("ASR_ENGINE", "openai_whisper")
 
@@ -45,3 +46,14 @@ class CONFIG:
     SUBTITLE_MAX_LINE_WIDTH = int(os.getenv("SUBTITLE_MAX_LINE_WIDTH", 1000))
     SUBTITLE_MAX_LINE_COUNT = int(os.getenv("SUBTITLE_MAX_LINE_COUNT", 2))
     SUBTITLE_HIGHLIGHT_WORDS = os.getenv("SUBTITLE_HIGHLIGHT_WORDS", "false").lower() == "true"
+
+    # Batching
+    # Path to the batch database
+    WORKDIR = os.getenv("WORKDIR", "/tmp/whisper_asr_webservice")
+    if not os.path.exists(WORKDIR):
+        os.makedirs(WORKDIR)
+
+    # How long to keep a batch process after its value been read - Default is 30 minutes
+    JOB_CLEANUP_AFTER_READ = int(os.getenv("JOB_CLEANUP_AFTER_READ", 1800))
+    # How long to keep a batch process after its value been abandoned (not read) - Default is 24 hours
+    JOB_CLEANUP_ABANDONED = int(os.getenv("JOB_CLEANUP_ABANDONED", 86400))

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -26,25 +26,6 @@ LANGUAGE_CODES = sorted(tokenizer.LANGUAGES.keys())
 async_svc = AsyncProcessing(asr_model)
 
 
-# def cleanup_old_batches():
-#     """Remove batches older than BATCH_TTL seconds"""
-#     while True:
-#         current_time = time.time()
-#         cutoff_time = current_time - BATCH_TTL
-
-#         with db_lock:
-#             with sqlite3.connect(DB_PATH) as conn:
-#                 conn.execute("DELETE FROM batches WHERE created_at < ?", (cutoff_time,))
-#                 conn.commit()
-
-#         time.sleep(BATCH_CLEANUP_INTERVAL)
-
-
-# # Initialize database and start cleanup thread
-# init_database()
-# cleanup_thread = threading.Thread(target=cleanup_old_batches, daemon=True)
-# cleanup_thread.start()
-
 projectMetadata = importlib.metadata.metadata("whisper-asr-webservice")
 app = FastAPI(
     title=projectMetadata["Name"].title().replace("-", " "),


### PR DESCRIPTION
## Description ##

closes #320

This adds support for async jobs. What this does is allows you to submit an audio for processing and receive a `job_id` which you can check back for later.

- Job data is stored in a sqlite DB
- Transcription results ARE NOT stored in sqlite DB, rather in a set of jobs
- Processing in the background in order using a queue
- Data is temporarily stored for a period of time

Jobs are cleaned up on two occasions:
https://github.com/syntaxsdev/whisper-asr-webservice/blob/3678d2aff95aff673fd4496e5aa8c2b11c1a6ae6/app/config.py#L56-L59
```PY
# How long to keep a batch process after its value been read - Default is 30 minutes
JOB_CLEANUP_AFTER_READ = int(os.getenv("JOB_CLEANUP_AFTER_READ", 1800))
# How long to keep a batch process after its value been abandoned (not read) - Default is 24 hours
JOB_CLEANUP_ABANDONED = int(os.getenv("JOB_CLEANUP_ABANDONED", 86400))
```

This means, once a job is processed, you have
- 24 hours (default) to read the value or it will be considered abandoned and deleted
- 30 minutes (default) after you read it before it is deleted

## Usage ##
POST `asr/` - just set the `async_job` param to `true`
Example response:
<img width="400" height="82" alt="image" src="https://github.com/user-attachments/assets/5a7d91c2-6f25-49d0-a29c-50d476a14fc6" />

to retrieve:
GET `asr/{job_id}` (new endpoint)
Example response: 
<img width="1293" height="210" alt="image" src="https://github.com/user-attachments/assets/2f04441c-9a96-4302-b972-8e30723343bb" />


In this particular example, I used diarization on WhisperX model as well.


If a failure occurs, it will display the status as `failed` and also be cleaned at the `JOB_CLEANUP_AFTER_READ` period.


## Other Notes ##
I've built it with support eventually to expand to async batch jobs, where you can upload multiple files at once (or multiple files into a job) and then eventually kick off the job, which is why the output is structured as such.

I think a separate PR would be warranted for that.

## Testing ##
- Tested both locally and containerized (CPU/GPU).
- Verified works in Kubernetes (OpenShift)
- Works with 921MB (nearly 1GB) audio file, tested on GPU - took 2 minutes

<img width="531" height="117" alt="image" src="https://github.com/user-attachments/assets/5e3b102e-56ed-4c31-b155-7b9ca770dbd4" />

Test containers:
`docker.io/syntaxsdev/whisper-asr-webservice:latest`
`docker.io/syntaxsdev/whisper-asr-webservice:latest-gpu`


